### PR TITLE
Small tweaks to mothur dataytpes.

### DIFF
--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -300,7 +300,7 @@ class DistanceMatrix(Text):
                 try:
                     dataset.metadata.sequence_count = int(''.join(line))  # seq count sometimes preceded by tab
                     break
-                except Exception, e:
+                except Exception as e:
                     log.warn("DistanceMatrix set_meta %s" % e)
 
 
@@ -608,7 +608,7 @@ class Frequency(Tabular):
                     try:
                         int(line[0])
                         float(line[1])
-                    except:
+                    except Exception:
                         return False
                 count += 1
         if count > 1:
@@ -658,7 +658,7 @@ class Quantile(Tabular):
                     float(line[4])
                     float(line[5])
                     float(line[6])
-                except:
+                except Exception:
                     return False
                 count += 1
         if count > 0:
@@ -780,7 +780,7 @@ class RefTaxonomy(Tabular):
                 if len(line) == 3:
                     try:
                         int(line[2])
-                    except:
+                    except Exception:
                         return False
                 count += 1
 
@@ -901,7 +901,7 @@ class SffFlow(Tabular):
         try:
             flow_values = int(headers[0][0])
             dataset.metadata.flow_values = flow_values
-        except Exception, e:
+        except Exception as e:
             log.warn("SffFlow set_meta %s" % e)
 
     def make_html_table(self, dataset, skipchars=[]):
@@ -919,7 +919,7 @@ class SffFlow(Tabular):
             out += '</tr>'
             out += self.make_html_peek_rows(dataset, skipchars=skipchars)
             out += '</table>'
-        except Exception, exc:
+        except Exception as exc:
             out = "Can't create peek %s" % str(exc)
         return out
 

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -343,6 +343,9 @@ def guess_ext( fname, sniff_order, is_multi_byte=False ):
     >>> fname = get_test_fname('5e5z.pdb')
     >>> guess_ext(fname, sniff_order)
     'pdb'
+    >>> fname = get_test_fname('mothur_datatypetest_true.mothur.otu')
+    >>> guess_ext(fname, sniff_order)
+    'mothur.otu'
     """
     for datatype in sniff_order:
         """


### PR DESCRIPTION
- Cleanup exception handling (Python 3 compatible exceptions and eliminate [bare exceptions](https://docs.python.org/2/howto/doanddont.html#except)) .
- Add an integration test for the otu datatypes - just to make sure the sniffers are added to sample configuration correctly.
